### PR TITLE
Fix "multiple definition error while compiling"

### DIFF
--- a/src/openbox-menu.h
+++ b/src/openbox-menu.h
@@ -82,8 +82,4 @@ gboolean context_get_persistent (OB_Menu*);
 
 void context_free(OB_Menu *);
 
-#ifdef WITH_ICONS
-	GtkIconTheme *icon_theme;
-#endif
-
 #endif // __OPENBOXMENU_APP__

--- a/src/utils.c
+++ b/src/utils.c
@@ -18,6 +18,7 @@
 #include <glib.h>
 #ifdef WITH_ICONS
 	#include <gtk/gtk.h>
+	GtkIconTheme *icon_theme;
 #endif
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
when the code is compiled it throws this error:
openbox-menu.h:86: multiple definition of `icon_theme';
I just move the definition from openbox-menu.h to utils.c